### PR TITLE
(ci run): Fix readonly userstores appearing in group and user creation wizards  @DonOmalVindula

### DIFF
--- a/.changeset/strange-rabbits-act.md
+++ b/.changeset/strange-rabbits-act.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.groups.v1": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Fix readonly userstores appearing in group and user creation wizards

--- a/features/admin.groups.v1/components/wizard/group-basics.tsx
+++ b/features/admin.groups.v1/components/wizard/group-basics.tsx
@@ -21,7 +21,8 @@ import { AppState } from "@wso2is/admin.core.v1/store";
 import { SharedUserStoreUtils } from "@wso2is/admin.core.v1/utils/user-store-utils";
 import { groupConfig, userstoresConfig } from "@wso2is/admin.extensions.v1";
 import { getAUserStore, getUserStoreList } from "@wso2is/admin.userstores.v1/api/user-stores";
-import { USERSTORE_REGEX_PROPERTIES, UserStoreManagementConstants } from "@wso2is/admin.userstores.v1/constants";
+import { USERSTORE_REGEX_PROPERTIES } from "@wso2is/admin.userstores.v1/constants";
+import useUserStoresContext from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
 import { UserStoreProperty } from "@wso2is/admin.userstores.v1/models";
 import { AlertLevels, IdentifiableComponentInterface, UserstoreListResponseInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -65,6 +66,7 @@ export const GroupBasics: FunctionComponent<GroupBasicProps> = (props: GroupBasi
 
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
+    const { isUserStoreReadOnly } = useUserStoresContext();
 
     const primaryUserStoreDomainName: string = useSelector((state: AppState) =>
         state?.config?.ui?.primaryUserStoreDomainName);
@@ -76,6 +78,7 @@ export const GroupBasics: FunctionComponent<GroupBasicProps> = (props: GroupBasi
     const groupName: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
 
     useEffect(() => {
+        // To-do: Replace this with userstore provider logic.
         getUserStores();
     }, []);
 
@@ -142,9 +145,7 @@ export const GroupBasics: FunctionComponent<GroupBasicProps> = (props: GroupBasi
         try {
             const response: UserStoreDetails = await getAUserStore(userStoreID);
 
-            return response?.properties?.some(({ name, value }: UserStoreProperty) =>
-                name === UserStoreManagementConstants.USER_STORE_PROPERTY_READ_ONLY && value === "false"
-            ) || false;
+            return !isUserStoreReadOnly(response?.name);
         } catch (error) {
             dispatch(addAlert({
                 description: t("userstores:notifications.fetchUserstores.genericError." +

--- a/features/admin.users.v1/components/wizard/add-user-wizard.tsx
+++ b/features/admin.users.v1/components/wizard/add-user-wizard.tsx
@@ -25,7 +25,7 @@ import { updateGroupDetails, useGroupList } from "@wso2is/admin.groups.v1/api/gr
 import { GroupsInterface } from "@wso2is/admin.groups.v1/models/groups";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { getAUserStore, useUserStores } from "@wso2is/admin.userstores.v1/api";
-import { UserStoreManagementConstants } from "@wso2is/admin.userstores.v1/constants";
+import useUserStoresContext from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
 import { UserStoreListItem, UserStorePostData, UserStoreProperty } from "@wso2is/admin.userstores.v1/models";
 import { useValidationConfigData } from "@wso2is/admin.validation.v1/api";
 import { ValidationFormInterface } from "@wso2is/admin.validation.v1/models";
@@ -124,6 +124,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
     const dispatch: Dispatch = useDispatch();
     const [ alert, setAlert, alertComponent ] = useWizardAlert();
     const { isSubOrganization } = useGetCurrentOrganizationType();
+    const { isUserStoreReadOnly } = useUserStoresContext();
 
     const [ submitGeneralSettings, setSubmitGeneralSettings ] = useTrigger();
     const [ submitGroupList, setSubmitGroupList ] = useTrigger();
@@ -178,6 +179,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
     );
 
     // Hook to get the user store list.
+    // To-do: Replace this with userstore provider logic.
     const {
         data: originalUserStoreList,
         isLoading: isUserStoreListFetchRequestLoading,
@@ -208,10 +210,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                         const isDisabled: boolean = response.properties.find(
                             (property: UserStoreProperty) => property.name === "Disabled")?.value === "true";
 
-                        const isReadOnly: boolean = response.properties.find(
-                            (property: UserStoreProperty) =>
-                                property.name === UserStoreManagementConstants.
-                                    USER_STORE_PROPERTY_READ_ONLY)?.value === "true";
+                        const isReadOnly: boolean = isUserStoreReadOnly(store.name);
 
                         if (!isDisabled && !isReadOnly) {
                             const storeOption: DropdownItemProps = {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
